### PR TITLE
Feat/label

### DIFF
--- a/src/components/Label/index.css.ts
+++ b/src/components/Label/index.css.ts
@@ -1,0 +1,45 @@
+import { style } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
+
+import { roundedRecipe } from "../../constants/rounded/index.css";
+import { theme } from "../../libs/createTheme.css";
+
+const containerBase = style({
+    padding: "6px 12px",
+    fontSize: "14px",
+    fontWeight: "bold",
+});
+
+const primary = style({
+    border: `2px solid ${theme.colors.primary.light}`,
+    backgroundColor: `${theme.colors.primary.main}`,
+    color: `${theme.colors.primary.contrastText}`,
+});
+
+const secondary = style({
+    border: `2px solid ${theme.colors.secondary.light}`,
+    backgroundColor: `${theme.colors.secondary.main}`,
+    color: `${theme.colors.secondary.contrastText}`,
+});
+
+const outlined = style({
+    backgroundColor: "transparent",
+    color: `${theme.colors.primary.main}`,
+});
+
+const contained = style({});
+
+export const label = recipe({
+    base: containerBase,
+    variants: {
+        color: {
+            primary: primary,
+            secondary: secondary,
+        },
+        variant: {
+            outlined: outlined,
+            contained: contained,
+        },
+        rounded: roundedRecipe,
+    },
+});

--- a/src/components/Label/index.stories.tsx
+++ b/src/components/Label/index.stories.tsx
@@ -1,0 +1,84 @@
+import { Label } from ".";
+
+import type { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof Label> = {
+    title: "Label",
+    component: Label,
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+    args: {
+        children: "label",
+    },
+};
+
+export const Primary: Story = {
+    args: {
+        children: "label",
+        color: "primary",
+    },
+};
+
+export const Secondary: Story = {
+    args: {
+        children: "label",
+        color: "secondary",
+    },
+};
+
+export const Contained: Story = {
+    args: {
+        children: "label",
+        variant: "contained",
+    },
+};
+
+export const Outlined: Story = {
+    args: {
+        children: "label",
+        variant: "outlined",
+    },
+};
+
+export const RoundedNone: Story = {
+    args: {
+        children: "label",
+        rounded: "none",
+    },
+};
+
+export const RoundedSmall: Story = {
+    args: {
+        children: "label",
+        rounded: "small",
+    },
+};
+
+export const RoundedMedium: Story = {
+    args: {
+        children: "label",
+        rounded: "medium",
+    },
+};
+
+export const RoundedLarge: Story = {
+    args: {
+        children: "label",
+        rounded: "large",
+    },
+};
+
+export const RoundedFull: Story = {
+    args: {
+        children: "label",
+        rounded: "full",
+    },
+};

--- a/src/components/Label/index.test.tsx
+++ b/src/components/Label/index.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import { Label } from ".";
+
+describe("Label component", () => {
+    it("renders with a class", () => {
+        const { container } = render(<Label>Test</Label>);
+        const div = container.firstChild as HTMLElement;
+        expect(div.className).toBeTruthy(); // クラス名が存在するかどうかを確認
+    });
+    it("renders with different class for different color", () => {
+        const { container: container1 } = render(
+            <Label color="primary">Test</Label>
+        );
+        const div1 = container1.firstChild as HTMLElement;
+
+        const { container: container2 } = render(
+            <Label color="secondary">Test</Label>
+        );
+        const div2 = container2.firstChild as HTMLElement;
+        if (div1 && div2) {
+            expect(div1.className).not.toEqual(div2.className); // 異なるcolorプロパティの値に基づいて異なるクラス名が生成されるかどうかを確認
+        } else {
+            throw new Error("div1 or div2 is undefined");
+        }
+    });
+    it("renders children correctly", () => {
+        const { getByText } = render(<Label>Child Content</Label>);
+        expect(getByText("Child Content")).toBeInTheDocument();
+    });
+});

--- a/src/components/Label/index.tsx
+++ b/src/components/Label/index.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+import { label } from "./index.css";
+
+import type { roundedKeys } from "../../constants/rounded/index.type";
+
+type Props = {
+    children: ReactNode;
+    color?: "primary" | "secondary";
+    variant?: "outlined" | "contained";
+    rounded?: roundedKeys;
+};
+
+/**
+ * @function
+ * A Label component that displays content with optional styling variants.
+ *
+ * @param children - The content to be displayed inside the label.
+ * @param color - The color scheme for the label. Defaults to "primary".
+ * @param variant - The visual style of the label. Defaults to "contained".
+ * @param rounded - The border-radius style for the label. Defaults to "full".
+ * @returns The rendered Label component.
+ */
+
+export const Label: React.FC<Props> = ({
+    children,
+    color = "primary",
+    variant = "contained",
+    rounded = "full",
+}) => <div className={label({ variant, color, rounded })}>{children}</div>;


### PR DESCRIPTION
# label 

### param
- variant `outlined` `contained`
- color `primary` `secondary`
- rounded `none` `small` `medium`  `large`  `full`

<img width="72" alt="スクリーンショット 2023-09-24 2 41 49" src="https://github.com/tosaken1116/fragment-ui/assets/94045195/e37e1988-777e-4f93-b788-5f5b56b7b2d0">
